### PR TITLE
Fix WebUI spelling in build messages

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -10,11 +10,11 @@ from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 class CustomBuildHook(BuildHookInterface):
     def initialize(self, version, build_data):
         super().initialize(version, build_data)
-        stderr.write(">>> Building Open Webui frontend\n")
+        stderr.write(">>> Building Open WebUI frontend\n")
         npm = shutil.which("npm")
         if npm is None:
             raise RuntimeError(
-                "NodeJS `npm` is required for building Open Webui but it was not found"
+                "NodeJS `npm` is required for building Open WebUI but it was not found"
             )
         stderr.write("### npm install\n")
         subprocess.run([npm, "install", "--force"], check=True)  # noqa: S603


### PR DESCRIPTION
## Summary
- update `hatch_build.py` to use "Open WebUI" wording in console output and error message

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688735702b7c83318b8d081e6f3b74e4